### PR TITLE
make example const correct

### DIFF
--- a/Presentations/DevMeetings/2017-06/PropertyInfo.md
+++ b/Presentations/DevMeetings/2017-06/PropertyInfo.md
@@ -32,10 +32,16 @@ In addition to addressing algorithm name violations and inconsistencies, we have
 		```
 		
 		Users would then retrieve a tuple of values:
+		
+		C++11/14
 		```cpp
-		const MatrixWorkspace_const_sptr inputWS;
-		const IndexSet indexSet;
+		MatrixWorkspace_const_sptr inputWS;
+		IndexSet indexSet;
 		std::tie(inputWS, indexSet) = getProperty("InputWorkspaceAndIndex");
+		```
+		C++17
+		```cpp
+		auto [inputWS, indexSet] = getProperty("InputWorkspaceAndIndex");
 		```
 		
 		or in python:


### PR DESCRIPTION
One shouldn't be able to assign to a const object.

This also adds an example using C++17 structured bindings.
